### PR TITLE
Add compatibility with PHP 5.5

### DIFF
--- a/Sources/ActivityBar.php
+++ b/Sources/ActivityBar.php
@@ -50,7 +50,7 @@ class ActivityBar extends Ohara
 		$config_vars[] = '';
 	}
 
-	public function data(&$data, $user, $display_custom_fields)
+	public function activity(&$data, $user, $display_custom_fields)
 	{
 		// Mod is disabled.
 		if(!$this->setting('enable'))

--- a/hooks.php
+++ b/hooks.php
@@ -14,7 +14,7 @@
 		exit('<b>Error:</b> Cannot install - please verify you put this in the same place as SMF\'s index.php.');
 
 	$hooks = array(
-		'integrate_member_context' => '$sourcedir/ActivityBar.php|ActivityBar::data#',
+		'integrate_member_context' => '$sourcedir/ActivityBar.php|ActivityBar::activity#',
 		'integrate_credits' => '$sourcedir/ActivityBar.php|ActivityBar::who#',
 		'integrate_general_mod_settings' => '$sourcedir/ActivityBar.php|ActivityBar::settings#',
 		'integrate_prepare_display_context' => '$sourcedir/ActivityBar.php|ActivityBar::showDisplay#',

--- a/remove.php
+++ b/remove.php
@@ -15,7 +15,7 @@
 		exit('Error Cannot remove - please verify you put this in the same place as SMF\'s index.php.');
 
 	$hooks = array(
-		'integrate_member_context' => '$sourcedir/ActivityBar.php|ActivityBar::data#',
+		'integrate_member_context' => '$sourcedir/ActivityBar.php|ActivityBar::activity#',
 		'integrate_credits' => '$sourcedir/ActivityBar.php|ActivityBar::who#',
 		'integrate_general_mod_settings' => '$sourcedir/ActivityBar.php|ActivityBar::settings#',
 		'integrate_prepare_display_context' => '$sourcedir/ActivityBar.php|ActivityBar::showDisplay#',


### PR DESCRIPTION
Strict standards: Declaration of ActivityBar::data() should be compatible with Ohara::data($var)

Signed-off-by: Suki suki@missallsunday.com
